### PR TITLE
Normalize login email handling

### DIFF
--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -7,7 +7,14 @@ class UserManager(BaseUserManager):
     def create_user(self, email, password=None, role=None, tenant=None, **extra_fields):
         if not email:
             raise ValueError('Users must have an email address')
+
         email = self.normalize_email(email)
+        if email:
+            email = email.strip()
+        if not email:
+            raise ValueError('Users must have an email address')
+        email = email.lower()
+
         role = role or self.model.Role.CLIENT
         if role not in dict(self.model.Role.choices):
             raise ValueError('Invalid role provided')

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -74,6 +74,21 @@ class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
         return token
 
     def validate(self, attrs):
+        email = attrs.get(self.username_field)
+        if email is not None:
+            normalized_email = email.strip()
+            if normalized_email:
+                attrs[self.username_field] = normalized_email
+                matching_user = User.objects.filter(
+                    **{f'{self.username_field}__iexact': normalized_email}
+                ).first()
+                if matching_user:
+                    attrs[self.username_field] = getattr(
+                        matching_user, self.username_field
+                    )
+            else:
+                attrs[self.username_field] = normalized_email
+
         data = super().validate(attrs)
         data.update(
             {

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1,3 +1,40 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+
+User = get_user_model()
+
+
+class LoginViewTests(TestCase):
+    def setUp(self):
+        self.password = 'StrongPass123!'
+        self.user = User.objects.create_user(
+            email='Owner@Example.com',
+            password=self.password,
+            role=User.Role.SUPERADMIN,
+        )
+        self.client.defaults['HTTP_HOST'] = 'localhost'
+        self.url = reverse('accounts:login')
+
+    def _post_login(self, email: str, password: str | None = None):
+        payload = json.dumps({'email': email, 'password': password or self.password})
+        return self.client.post(self.url, data=payload, content_type='application/json')
+
+    def test_login_accepts_case_insensitive_email(self):
+        response = self._post_login('OWNER@example.COM')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertIn('access', body)
+        self.assertIn('refresh', body)
+
+    def test_login_strips_whitespace_from_email(self):
+        response = self._post_login('  owner@example.com  ')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertIn('access', body)
+        self.assertIn('refresh', body)


### PR DESCRIPTION
## Summary
- normalize user creation emails by stripping whitespace and lowercasing before saving
- accept case-insensitive and trimmed email addresses when issuing JWT login tokens
- cover the login flow with tests for mixed-case and whitespace emails

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_b_68cbf6fbfa788324b1d807a6c8fa3692