### PR TITLE
Fix AuthGuard canActivateChild implementation

### DIFF
--- a/frontend/sports/src/app/auth/guards/auth.guard.ts
+++ b/frontend/sports/src/app/auth/guards/auth.guard.ts
@@ -1,14 +1,24 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router, UrlTree } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
 import { Observable, map } from 'rxjs';
 
 import { AuthService } from '../services/auth.service';
 
 @Injectable({ providedIn: 'root' })
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate, CanActivateChild {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(): Observable<boolean | UrlTree> | boolean | UrlTree {
+  canActivate(
+    _route: ActivatedRouteSnapshot,
+    _state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | boolean | UrlTree {
     if (!this.authService.isAuthenticated()) {
       return this.router.parseUrl('/auth/login');
     }
@@ -16,5 +26,12 @@ export class AuthGuard implements CanActivate {
     return this.authService.ensureProfileLoaded().pipe(
       map((isLoaded) => (isLoaded ? true : this.router.parseUrl('/auth/login')))
     );
+  }
+
+  canActivateChild(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | boolean | UrlTree {
+    return this.canActivate(route, state);
   }
 }


### PR DESCRIPTION
## Summary
- update AuthGuard to implement CanActivateChild and delegate to canActivate
- expand the guard method signatures to receive route and state arguments

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68cc028876548324b9b5fc676f805670